### PR TITLE
docs(readme): fix SQL file path (moved to docs/bbdd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here you can see the ER Diagram:
 
    * Open [phpMyAdmin](http://localhost/phpmyadmin)
    * Create a new database (e.g., enjoyandlearn)
-   * Import the file `documents/escuela_idiomas.sql`.
+   * Import the file `docs/bbdd/escuela_idiomas.sql`.
 
 4. Open your browser at [localhost](http://localhost/enjoyAndLearnVanilla/index.html)
 


### PR DESCRIPTION
This is a hotfix to correct the SQL file path in README, since the file was reorganized under `docs/bbdd`.

## Checklist
- [x] The path exists in the repo
- [x] README renders correctly in GitHub
- [x] No other references to the old path remain